### PR TITLE
feat: skill system, .mg discovery, interactive stdin fix

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -15,6 +14,26 @@ import (
 	"github.com/tesh254/migraine/internal/workflow"
 	"github.com/tesh254/migraine/pkg/utils"
 )
+
+func readLine() string {
+	var buf [1]byte
+	var line []byte
+	for {
+		n, err := os.Stdin.Read(buf[:])
+		if n > 0 {
+			if buf[0] == '\n' {
+				break
+			}
+			if buf[0] != '\r' {
+				line = append(line, buf[0])
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	return string(line)
+}
 
 func handleListWorkflows() {
 	// List workflows from database
@@ -166,20 +185,12 @@ func handleRunWorkflowV2(workflowName string, cmd *cobra.Command) {
 
 	// If there are still missing variables, prompt for them if not using vault
 	if !useVault {
-		reader := bufio.NewReader(os.Stdin)
-
-		// Get all required variables from the workflow content
 		requiredVars := utils.ExtractTemplateVars(workflowContent)
 
 		for _, v := range requiredVars {
 			if _, exists := resolvedVars[v]; !exists {
 				fmt.Printf("%s: ", v)
-				value, err := reader.ReadString('\n')
-				if err != nil {
-					utils.LogError(fmt.Sprintf("Failed to read input: %v", err))
-					os.Exit(1)
-				}
-				resolvedVars[v] = strings.TrimSpace(value)
+				resolvedVars[v] = readLine()
 			}
 		}
 	}
@@ -477,10 +488,6 @@ func handleRunProjectWorkflow(cmd *cobra.Command) {
 
 	// If there are still missing variables, prompt for them if not using vault
 	if !projWf.UseVault {
-		reader := bufio.NewReader(os.Stdin)
-
-		// Get all required variables from the workflow content
-		// For project workflow, we need to check all steps and actions
 		var workflowContent string
 		for _, step := range projWf.Steps {
 			workflowContent += step.Command + "\n"
@@ -497,12 +504,7 @@ func handleRunProjectWorkflow(cmd *cobra.Command) {
 		for _, v := range requiredVars {
 			if _, exists := resolvedVars[v]; !exists {
 				fmt.Printf("%s: ", v)
-				value, err := reader.ReadString('\n')
-				if err != nil {
-					utils.LogError(fmt.Sprintf("Failed to read input: %v", err))
-					os.Exit(1)
-				}
-				resolvedVars[v] = strings.TrimSpace(value)
+				resolvedVars[v] = readLine()
 			}
 		}
 	}
@@ -757,7 +759,6 @@ func handleRunProjectPreChecks(cmd *cobra.Command) {
 
 	// If there are still missing variables, prompt for them if not using vault
 	if !projWf.UseVault {
-		reader := bufio.NewReader(os.Stdin)
 		workflowContent := ""
 		for _, check := range projWf.PreChecks {
 			workflowContent += check.Command + "\n"
@@ -766,12 +767,7 @@ func handleRunProjectPreChecks(cmd *cobra.Command) {
 		for _, v := range requiredVars {
 			if _, exists := resolvedVars[v]; !exists {
 				fmt.Printf("%s: ", v)
-				value, err := reader.ReadString('\n')
-				if err != nil {
-					utils.LogError(fmt.Sprintf("Failed to read input: %v", err))
-					os.Exit(1)
-				}
-				resolvedVars[v] = strings.TrimSpace(value)
+				resolvedVars[v] = readLine()
 			}
 		}
 	}
@@ -891,7 +887,6 @@ func handleRunWorkflowPreChecksFromStoredDirectory(workflowName string, cmd *cob
 
 	// If missing variables, prompt
 	if !useVault {
-		reader := bufio.NewReader(os.Stdin)
 		workflowContent := ""
 		for _, check := range preChecks {
 			workflowContent += check.Command + "\n"
@@ -900,12 +895,7 @@ func handleRunWorkflowPreChecksFromStoredDirectory(workflowName string, cmd *cob
 		for _, v := range requiredVars {
 			if _, exists := resolvedVars[v]; !exists {
 				fmt.Printf("%s: ", v)
-				value, err := reader.ReadString('\n')
-				if err != nil {
-					utils.LogError(fmt.Sprintf("Failed to read input: %v", err))
-					os.Exit(1)
-				}
-				resolvedVars[v] = strings.TrimSpace(value)
+				resolvedVars[v] = readLine()
 			}
 		}
 	}

--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -1,0 +1,278 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tesh254/migraine/internal/skill"
+	"github.com/tesh254/migraine/internal/ui"
+)
+
+var skillCmd = &cobra.Command{
+	Use:     "skill",
+	Aliases: []string{"sk"},
+	Short:   "Manage workflow skills (pre-built workflow templates)",
+	Long: `Manage workflow skills — pre-built workflow templates for common tasks.
+
+Skills are ready-to-use workflow definitions that can be installed globally
+or per-project. They cover common patterns like deployments, CI pipelines,
+and Git workflows.
+
+Installation scopes:
+  --global   Install to ~/.migraine/skills/ (available everywhere)
+  --project  Install to ./.migraine/skills/ (available in this project only)
+
+For non-interactive / agent use, specify a skill name and scope directly:
+  migraine skill add docker-deploy --global
+  migraine skill add docker-deploy --project
+
+Agent integration:
+  migraine skill init --agent opencode
+  migraine skill init --agent claude
+  migraine skill init --agent codex`,
+}
+
+var skillListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available and installed skills",
+	Long: `List all available built-in skills and any currently installed skills.
+
+Shows skill name, category, description, and tags for each available skill.
+Installed skills are marked with their scope (global or project).`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ui.SectionHeader("Available Skills")
+		skills := skill.List()
+		if len(skills) == 0 {
+			fmt.Println("  No skills available.")
+			return
+		}
+
+		categories := make(map[string][]skill.Skill)
+		for _, s := range skills {
+			categories[s.Category] = append(categories[s.Category], s)
+		}
+
+		for cat, catSkills := range categories {
+			fmt.Printf("\n  %s:\n", strings.Title(cat))
+			for _, s := range catSkills {
+				tags := ""
+				if len(s.Tags) > 0 {
+					tags = fmt.Sprintf(" [%s]", strings.Join(s.Tags, ", "))
+				}
+				fmt.Printf("    %-20s %s%s\n", s.Name, s.Description, tags)
+			}
+		}
+
+		installed, err := skill.ListInstalled()
+		if err == nil && len(installed) > 0 {
+			ui.SectionHeader("Installed")
+			for _, i := range installed {
+				fmt.Printf("  • %s\n", i)
+			}
+		}
+
+		fmt.Println("\n  Use 'migraine skill add <name> --global|--project' to install a skill.")
+	},
+}
+
+var skillAddCmd = &cobra.Command{
+	Use:   "add [name]",
+	Short: "Install a skill (interactive if no flags)",
+	Long: `Install a workflow skill.
+
+If --global or --project is specified, installs non-interactively.
+If no scope flag is given, prompts for the scope interactively.
+
+For agents and scripts:
+  migraine skill add docker-deploy --global
+  migraine skill add docker-deploy --project
+
+For interactive use:
+  migraine skill add docker-deploy`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		globalFlag, _ := cmd.Flags().GetBool("global")
+		projectFlag, _ := cmd.Flags().GetBool("project")
+
+		scope := ""
+		if globalFlag {
+			scope = "global"
+		} else if projectFlag {
+			scope = "project"
+		} else {
+			fmt.Printf("Install '%s' globally or per-project? [global/project]: ", name)
+			input := strings.TrimSpace(strings.ToLower(readLine()))
+			switch input {
+			case "global", "g":
+				scope = "global"
+			case "project", "p", "local":
+				scope = "project"
+			default:
+				fmt.Println("  Defaulting to project scope.")
+				scope = "project"
+			}
+		}
+
+		return skill.Install(name, scope)
+	},
+}
+
+var skillRemoveCmd = &cobra.Command{
+	Use:     "remove [name]",
+	Aliases: []string{"rm"},
+	Short:   "Remove an installed skill",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return skill.Remove(args[0])
+	},
+}
+
+var skillShowCmd = &cobra.Command{
+	Use:   "show [name]",
+	Short: "Show skill details and .mg format preview",
+	Long: `Show detailed information about a skill, including its full workflow
+definition and a preview of the .mg format output.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		s, ok := skill.Find(args[0])
+		if !ok {
+			return fmt.Errorf("skill '%s' not found. Use 'migraine skill list' to see available skills", args[0])
+		}
+
+		mgFlag, _ := cmd.Flags().GetBool("mg")
+
+		ui.SectionHeader(fmt.Sprintf("Skill: %s", s.Name))
+		fmt.Printf("  Description: %s\n", s.Description)
+		fmt.Printf("  Category:    %s\n", s.Category)
+		if len(s.Tags) > 0 {
+			fmt.Printf("  Tags:        %s\n", strings.Join(s.Tags, ", "))
+		}
+		if len(s.Variables) > 0 {
+			fmt.Printf("  Variables:   %s\n", strings.Join(mapKeys(s.Variables), ", "))
+		}
+
+		fmt.Printf("\n  Pre-checks: %d\n", len(s.Workflow.PreChecks))
+		fmt.Printf("  Steps:       %d\n", len(s.Workflow.Steps))
+		fmt.Printf("  Actions:     %d\n", len(s.Workflow.Actions))
+
+		if mgFlag {
+			fmt.Printf("\n--- .mg format ---\n%s\n--- end ---\n", skill.RenderMG(s))
+		}
+
+		return nil
+	},
+}
+
+var skillSearchCmd = &cobra.Command{
+	Use:   "search [query]",
+	Short: "Search available skills by name, category, or tag",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		results := skill.Search(args[0])
+		if len(results) == 0 {
+			fmt.Printf("No skills matching '%s' found.\n", args[0])
+			return
+		}
+
+		ui.SectionHeader(fmt.Sprintf("Search: %s", args[0]))
+		for _, s := range results {
+			tags := ""
+			if len(s.Tags) > 0 {
+				tags = fmt.Sprintf(" [%s]", strings.Join(s.Tags, ", "))
+			}
+			fmt.Printf("  %-20s %s%s\n", s.Name, s.Description, tags)
+		}
+	},
+}
+
+var skillInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Set up agent integration for migraine skills",
+	Long: `Configure an AI coding agent to recognize migraine skills and workflows.
+
+Generates the appropriate config file for the agent so it knows about
+available skills and how to invoke them.
+
+Supported agents: opencode, claude, codex, cursor, windsurf, cline
+
+For non-interactive / agent use, specify --agent directly:
+  migraine skill init --agent opencode
+
+For interactive use:
+  migraine skill init`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		agentFlag, _ := cmd.Flags().GetString("agent")
+
+		if agentFlag != "" {
+			agentConfig, ok := skill.FindAgent(agentFlag)
+			if !ok {
+				return fmt.Errorf("unsupported agent '%s'. Supported: %s", agentFlag, skill.AgentList())
+			}
+
+			allSkills := skill.List()
+			installed, _ := skill.ListInstalled()
+
+			var skillsToInclude []skill.Skill
+			if len(installed) > 0 {
+				skillsToInclude = allSkills
+			} else {
+				skillsToInclude = allSkills
+			}
+
+			return skill.SetupAgent(agentConfig.Name, skillsToInclude)
+		}
+
+		fmt.Println("Which agent would you like to configure?")
+		fmt.Println()
+		agents := skill.SupportedAgents()
+		for i, a := range agents {
+			fmt.Printf("  %d. %s (%s)\n", i+1, a.DisplayName, a.ConfigFile)
+		}
+		fmt.Println()
+
+		fmt.Print("Select agent [number or name]: ")
+		input := strings.TrimSpace(strings.ToLower(readLine()))
+
+		var selected *skill.AgentConfig
+		for i, a := range agents {
+			if input == fmt.Sprintf("%d", i+1) || input == a.Name {
+				selected = &agents[i]
+				break
+			}
+		}
+
+		if selected == nil {
+			return fmt.Errorf("invalid selection. Supported agents: %s", skill.AgentList())
+		}
+
+		return skill.SetupAgent(selected.Name, skill.List())
+	},
+}
+
+func mapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func init() {
+	skillAddCmd.Flags().Bool("global", false, "Install skill globally (~/.migraine/skills/)")
+	skillAddCmd.Flags().Bool("project", false, "Install skill per-project (./.migraine/skills/)")
+
+	skillShowCmd.Flags().Bool("mg", false, "Show skill in .mg format")
+
+	skillInitCmd.Flags().String("agent", "", "Agent to configure (opencode, claude, codex, cursor, windsurf, cline)")
+
+	skillCmd.AddCommand(skillListCmd)
+	skillCmd.AddCommand(skillAddCmd)
+	skillCmd.AddCommand(skillRemoveCmd)
+	skillCmd.AddCommand(skillShowCmd)
+	skillCmd.AddCommand(skillSearchCmd)
+	skillCmd.AddCommand(skillInitCmd)
+
+	rootCmd.AddCommand(skillCmd)
+}

--- a/examples/test-interactive.mg
+++ b/examples/test-interactive.mg
@@ -1,0 +1,16 @@
+variables {
+    name = "test-interactive"
+}
+
+workflow {
+    steps [
+        {
+            cmd = `bash -c 'read -p "Do you want to proceed? (y/n): " answer && echo "You answered: $answer"'`
+            desc = "Test boolean input prompt"
+        },
+        {
+            cmd = `bash -c 'read -p "Deploy to production? (y/n): " confirm && if [ "$confirm" = "y" ]; then echo "Deploying..."; else echo "Cancelled."; fi'`
+            desc = "Test another yes/no prompt"
+        }
+    ]
+}

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,9 @@
 module github.com/tesh254/migraine
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.0
 
 require (
 	github.com/charmbracelet/fang v0.1.0
-	github.com/creack/pty v1.1.24
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/spf13/cobra v1.9.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -60,5 +57,5 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	go.opencensus.io v0.22.5 // indirect
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.37.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
-github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -194,8 +192,8 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
-golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=

--- a/internal/execution/shell.go
+++ b/internal/execution/shell.go
@@ -3,14 +3,10 @@ package execution
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"os/user"
-	"path/filepath"
 	"strings"
-
-	"github.com/creack/pty"
 )
 
 func getDefaultShell() string {
@@ -39,43 +35,15 @@ func getDefaultShell() string {
 
 func ExecuteCommand(command string) error {
 	shell := getDefaultShell()
-	shellName := filepath.Base(shell)
 
-	var cmd *exec.Cmd
-	switch shellName {
-	case "bash":
-		cmd = exec.Command(shell, "--login", "-c", command)
-	case "zsh":
-		cmd = exec.Command(shell, "-l", "-c", command)
-	case "fish":
-		cmd = exec.Command(shell, "-l", "-c", command)
-	default:
-		cmd = exec.Command(shell, "-c", command)
-	}
-
+	cmd := exec.Command(shell, "-c", command)
 	cmd.Env = os.Environ()
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
-	ptmx, err := pty.Start(cmd)
-	if err != nil {
-		return fmt.Errorf("failed to start command: %v", err)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("command failed: %w", err)
 	}
-	defer ptmx.Close()
-
-	const (
-		colorGray  = "\033[90m"
-		fontSmall  = "\033[2m"
-		resetCodes = "\033[0m"
-	)
-
-	fmt.Fprint(os.Stdout, colorGray+fontSmall)
-
-	_, err = io.Copy(os.Stdout, ptmx)
-
-	fmt.Fprint(os.Stdout, resetCodes)
-
-	if err != nil {
-		return err
-	}
-
-	return cmd.Wait()
+	return nil
 }

--- a/internal/execution/shell_test.go
+++ b/internal/execution/shell_test.go
@@ -1,0 +1,68 @@
+package execution
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetDefaultShell_EnvVar(t *testing.T) {
+	origShell := os.Getenv("SHELL")
+	defer os.Setenv("SHELL", origShell)
+
+	os.Setenv("SHELL", "/bin/zsh")
+	shell := getDefaultShell()
+	if shell != "/bin/zsh" {
+		t.Errorf("expected /bin/zsh, got %s", shell)
+	}
+}
+
+func TestGetDefaultShell_CustomPath(t *testing.T) {
+	origShell := os.Getenv("SHELL")
+	defer os.Setenv("SHELL", origShell)
+
+	os.Setenv("SHELL", "/usr/local/bin/fish")
+	shell := getDefaultShell()
+	if shell != "/usr/local/bin/fish" {
+		t.Errorf("expected /usr/local/bin/fish, got %s", shell)
+	}
+}
+
+func TestExecuteCommand_Echo(t *testing.T) {
+	if os.Getenv("GO_TEST_WAS_RUN") != "" {
+		return
+	}
+
+	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" {
+		t.Skip("skipping PTY test in CI environment")
+	}
+
+	tmpScript := filepath.Join(t.TempDir(), "test_script.sh")
+	content := []byte("#!/bin/sh\necho hello\n")
+	if err := os.WriteFile(tmpScript, content, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ExecuteCommand("sh " + tmpScript)
+	if err != nil {
+		t.Errorf("ExecuteCommand failed: %v", err)
+	}
+}
+
+func TestGetDefaultShell_Fallback(t *testing.T) {
+	origShell := os.Getenv("SHELL")
+	origHome := os.Getenv("HOME")
+	defer func() {
+		os.Setenv("SHELL", origShell)
+		os.Setenv("HOME", origHome)
+	}()
+
+	os.Setenv("SHELL", "")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+
+	shell := getDefaultShell()
+	if shell != "/bin/sh" {
+		t.Errorf("expected /bin/sh fallback, got %s", shell)
+	}
+}

--- a/internal/skill/.clinerules
+++ b/internal/skill/.clinerules
@@ -1,0 +1,10 @@
+# Migraine CLI
+
+Migraine is a workflow automation CLI.
+
+## Available Skills
+- **migraine-workflow** — Scaffold a new migraine workflow from scratch
+  Usage: `migraine run migraine-workflow`
+
+
+Use `migraine skill add <name> --project` to install, `migraine run <name>` to run.

--- a/internal/skill/.cursorrules
+++ b/internal/skill/.cursorrules
@@ -1,0 +1,15 @@
+# Migraine CLI Rules
+
+Migraine is a workflow automation CLI.
+
+## Available Skills
+- **migraine-workflow** — Scaffold a new migraine workflow from scratch
+  Usage: `migraine run migraine-workflow`
+
+
+## Usage
+- Install: `migraine skill add <name> --project`
+- Run: `migraine run <name>`
+- List: `migraine skill list`
+
+When asked to set up CI, deployment, or Git workflows, check `migraine skill list` first.

--- a/internal/skill/.windsurfrules
+++ b/internal/skill/.windsurfrules
@@ -1,0 +1,15 @@
+# Migraine CLI Rules
+
+Migraine is a workflow automation CLI.
+
+## Available Skills
+- **migraine-workflow** — Scaffold a new migraine workflow from scratch
+  Usage: `migraine run migraine-workflow`
+
+
+## Usage
+- Install: `migraine skill add <name> --project`
+- Run: `migraine run <name>`
+- List: `migraine skill list`
+
+When asked to set up CI, deployment, or Git workflows, check `migraine skill list` first.

--- a/internal/skill/AGENTS.md
+++ b/internal/skill/AGENTS.md
@@ -1,0 +1,61 @@
+# Migraine CLI — Agent Instructions
+
+## Overview
+Migraine is a workflow automation CLI. It defines, stores, and runs sequences of shell commands with variable substitution, pre-flight checks, and discrete actions.
+
+## Key Commands
+- `migraine run <workflow>` — Run a workflow by name
+- `migraine run` — Run the project workflow (migraine.yml in CWD)
+- `migraine workflow list` — List all workflows
+- `migraine skill add <name> --project` — Install a skill per-project
+- `migraine skill add <name> --global` — Install a skill globally
+- `migraine skill list` — List available skills
+- `migraine init --editor <vscode|neovim|vim|helix>` — Configure editor LSP
+
+## Workflow Format (.mg)
+Workflows can be defined in .mg files:
+```mg
+metadata {
+    name = "my-workflow"
+    desc = "Description"
+}
+
+workflow {
+    steps [
+        { cmd = `echo hello`, desc = "Say hello" }
+    ]
+}
+```
+
+Variables use `args:VAR`, `env:VAR`, or `vault:VAR` prefixes.
+
+## Available Skills
+- **migraine-workflow** — Scaffold a new migraine workflow from scratch
+  Usage: `migraine run migraine-workflow`
+
+
+## Working with Skills
+When the user asks to set up a workflow:
+1. Check if a built-in skill matches: `migraine skill list`
+2. Install it: `migraine skill add <name> --project`
+3. Run it: `migraine run <name>`
+
+For custom workflows, create a .mg file or migraine.yml in the project root.
+
+
+# Migraine CLI
+
+Migraine automates workflows via CLI with variable substitution and hook support.
+
+## Commands
+- `migraine run <workflow>` — Run a workflow by name
+- `migraine skill add <name> --project` — Install a skill for this project
+- `migraine skill add <name> --global` — Install a skill globally
+- `migraine skill list` — List available skills
+
+## Skills
+- **migraine-workflow** — Scaffold a new migraine workflow from scratch
+  Usage: `migraine run migraine-workflow`
+
+
+Use `migraine skill add <name> --project` to install a skill, then `migraine run <name>` to run it.

--- a/internal/skill/CLAUDE.md
+++ b/internal/skill/CLAUDE.md
@@ -1,0 +1,25 @@
+# Migraine CLI
+
+Migraine is a workflow automation CLI for defining, storing, and running sequences of shell commands.
+
+## Commands
+- `migraine run <name>` — Run a workflow
+- `migraine skill add <name> --project` — Install a skill
+- `migraine skill list` — List available skills
+- `migraine init --editor <editor>` — Set up editor LSP
+
+## Available Skills
+- **migraine-workflow** — Scaffold a new migraine workflow from scratch
+  Usage: `migraine run migraine-workflow`
+
+
+When building workflows, prefer installing a skill over writing from scratch:
+`migraine skill add <name> --project`
+
+For custom workflows use .mg format:
+```mg
+metadata { name = "my-workflow" }
+workflow {
+    steps [{ cmd = `command`, desc = "description" }]
+}
+```

--- a/internal/skill/agent.go
+++ b/internal/skill/agent.go
@@ -1,0 +1,269 @@
+package skill
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tesh254/migraine/internal/ui"
+)
+
+type AgentConfig struct {
+	Name        string
+	DisplayName string
+	ConfigFile  string
+	Generate    func(dir string, skills []Skill) error
+}
+
+var supportedAgents = []AgentConfig{
+	{
+		Name:        "opencode",
+		DisplayName: "opencode",
+		ConfigFile:  "AGENTS.md",
+		Generate:    generateOpenCode,
+	},
+	{
+		Name:        "claude",
+		DisplayName: "Claude Code",
+		ConfigFile:  "CLAUDE.md",
+		Generate:    generateClaude,
+	},
+	{
+		Name:        "codex",
+		DisplayName: "OpenAI Codex",
+		ConfigFile:  "AGENTS.md",
+		Generate:    generateCodex,
+	},
+	{
+		Name:        "cursor",
+		DisplayName: "Cursor",
+		ConfigFile:  ".cursorrules",
+		Generate:    generateCursor,
+	},
+	{
+		Name:        "windsurf",
+		DisplayName: "Windsurf",
+		ConfigFile:  ".windsurfrules",
+		Generate:    generateWindsurf,
+	},
+	{
+		Name:        "cline",
+		DisplayName: "Cline",
+		ConfigFile:  ".clinerules",
+		Generate:    generateCline,
+	},
+}
+
+func SupportedAgents() []AgentConfig {
+	return supportedAgents
+}
+
+func FindAgent(name string) (*AgentConfig, bool) {
+	for _, a := range supportedAgents {
+		if a.Name == name {
+			return &a, true
+		}
+	}
+	return nil, false
+}
+
+func SetupAgent(agentName string, skills []Skill) error {
+	agent, ok := FindAgent(agentName)
+	if !ok {
+		return fmt.Errorf("unsupported agent '%s'. Supported: %s", agentName, AgentList())
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %v", err)
+	}
+
+	if err := agent.Generate(cwd, skills); err != nil {
+		return err
+	}
+
+	ui.LogSuccessBordered(fmt.Sprintf("Agent config generated for %s", agent.DisplayName))
+	fmt.Printf("  Config file: %s\n", filepath.Join(cwd, agent.ConfigFile))
+	return nil
+}
+
+func AgentList() string {
+	names := make([]string, len(supportedAgents))
+	for i, a := range supportedAgents {
+		names[i] = a.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+func skillReference(skills []Skill) string {
+	var b strings.Builder
+	for _, s := range skills {
+		b.WriteString(fmt.Sprintf("- **%s** — %s\n", s.Name, s.Description))
+		if len(s.Variables) > 0 {
+			b.WriteString(fmt.Sprintf("  Variables: %s\n", strings.Join(mapKeys(s.Variables), ", ")))
+		}
+		b.WriteString(fmt.Sprintf("  Usage: `migraine run %s`\n", s.Name))
+	}
+	return b.String()
+}
+
+func generateOpenCode(dir string, skills []Skill) error {
+	path := filepath.Join(dir, "AGENTS.md")
+	content := fmt.Sprintf(`# Migraine CLI — Agent Instructions
+
+## Overview
+Migraine is a workflow automation CLI. It defines, stores, and runs sequences of shell commands with variable substitution, pre-flight checks, and discrete actions.
+
+## Key Commands
+- `+"`migraine run <workflow>`"+` — Run a workflow by name
+- `+"`migraine run`"+` — Run the project workflow (migraine.yml in CWD)
+- `+"`migraine workflow list`"+` — List all workflows
+- `+"`migraine skill add <name> --project`"+` — Install a skill per-project
+- `+"`migraine skill add <name> --global`"+` — Install a skill globally
+- `+"`migraine skill list`"+` — List available skills
+- `+"`migraine init --editor <vscode|neovim|vim|helix>`"+` — Configure editor LSP
+
+## Workflow Format (.mg)
+Workflows can be defined in .mg files:
+`+"```"+`mg
+metadata {
+    name = "my-workflow"
+    desc = "Description"
+}
+
+workflow {
+    steps [
+        { cmd = `+"`echo hello`"+`, desc = "Say hello" }
+    ]
+}
+`+"```"+`
+
+Variables use `+"`args:VAR`"+`, `+"`env:VAR`"+`, or `+"`vault:VAR`"+` prefixes.
+
+## Available Skills
+%s
+
+## Working with Skills
+When the user asks to set up a workflow:
+1. Check if a built-in skill matches: `+"`migraine skill list`"+`
+2. Install it: `+"`migraine skill add <name> --project`"+`
+3. Run it: `+"`migraine run <name>`"+`
+
+For custom workflows, create a .mg file or migraine.yml in the project root.
+`, skillReference(skills))
+	return writeFile(path, content)
+}
+
+func generateClaude(dir string, skills []Skill) error {
+	path := filepath.Join(dir, "CLAUDE.md")
+	content := fmt.Sprintf(`# Migraine CLI
+
+Migraine is a workflow automation CLI for defining, storing, and running sequences of shell commands.
+
+## Commands
+- `+"`migraine run <name>`"+` — Run a workflow
+- `+"`migraine skill add <name> --project`"+` — Install a skill
+- `+"`migraine skill list`"+` — List available skills
+- `+"`migraine init --editor <editor>`"+` — Set up editor LSP
+
+## Available Skills
+%s
+
+When building workflows, prefer installing a skill over writing from scratch:
+`+"`migraine skill add <name> --project`"+`
+
+For custom workflows use .mg format:
+`+"```mg"+`
+metadata { name = "my-workflow" }
+workflow {
+    steps [{ cmd = `+"`command`"+`, desc = "description" }]
+}
+`+"```"+`
+`, skillReference(skills))
+	return writeFile(path, content)
+}
+
+func generateCodex(dir string, skills []Skill) error {
+	path := filepath.Join(dir, "AGENTS.md")
+	content := fmt.Sprintf(`# Migraine CLI
+
+Migraine automates workflows via CLI with variable substitution and hook support.
+
+## Commands
+- `+"`migraine run <workflow>`"+` — Run a workflow by name
+- `+"`migraine skill add <name> --project`"+` — Install a skill for this project
+- `+"`migraine skill add <name> --global`"+` — Install a skill globally
+- `+"`migraine skill list`"+` — List available skills
+
+## Skills
+%s
+
+Use `+"`migraine skill add <name> --project`"+` to install a skill, then `+"`migraine run <name>`"+` to run it.
+`, skillReference(skills))
+	return writeFile(path, content)
+}
+
+func generateCursor(dir string, skills []Skill) error {
+	path := filepath.Join(dir, ".cursorrules")
+	content := fmt.Sprintf(`# Migraine CLI Rules
+
+Migraine is a workflow automation CLI.
+
+## Available Skills
+%s
+
+## Usage
+- Install: `+"`migraine skill add <name> --project`"+`
+- Run: `+"`migraine run <name>`"+`
+- List: `+"`migraine skill list`"+`
+
+When asked to set up CI, deployment, or Git workflows, check `+"`migraine skill list`"+` first.
+`, skillReference(skills))
+	return writeFile(path, content)
+}
+
+func generateWindsurf(dir string, skills []Skill) error {
+	path := filepath.Join(dir, ".windsurfrules")
+	content := fmt.Sprintf(`# Migraine CLI Rules
+
+Migraine is a workflow automation CLI.
+
+## Available Skills
+%s
+
+## Usage
+- Install: `+"`migraine skill add <name> --project`"+`
+- Run: `+"`migraine run <name>`"+`
+- List: `+"`migraine skill list`"+`
+
+When asked to set up CI, deployment, or Git workflows, check `+"`migraine skill list`"+` first.
+`, skillReference(skills))
+	return writeFile(path, content)
+}
+
+func generateCline(dir string, skills []Skill) error {
+	path := filepath.Join(dir, ".clinerules")
+	content := fmt.Sprintf(`# Migraine CLI
+
+Migraine is a workflow automation CLI.
+
+## Available Skills
+%s
+
+Use `+"`migraine skill add <name> --project`"+` to install, `+"`migraine run <name>`"+` to run.
+`, skillReference(skills))
+	return writeFile(path, content)
+}
+
+func writeFile(path, content string) error {
+	existing, err := os.ReadFile(path)
+	if err == nil && len(existing) > 0 {
+		marker := "<!-- migraine-skills -->"
+		if strings.Contains(string(existing), marker) {
+			return os.WriteFile(path, []byte(content), 0644)
+		}
+		content = string(existing) + "\n\n" + content
+	}
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/internal/skill/agent_test.go
+++ b/internal/skill/agent_test.go
@@ -1,0 +1,207 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testSkills() []Skill {
+	return []Skill{
+		{
+			Name:        "migraine-workflow",
+			Description:  "Scaffold a new migraine workflow from scratch",
+			Category:    "migraine",
+			Tags:        []string{"migraine", "workflow", "scaffold"},
+			Workflow: SkillWorkflow{
+				Steps: []SkillStep{
+					{Command: "migraine workflow init", Description: strPtr("Create migraine.yml project config")},
+				},
+			},
+		},
+	}
+}
+
+func TestSupportedAgents(t *testing.T) {
+	agents := SupportedAgents()
+	if len(agents) == 0 {
+		t.Fatal("expected at least one supported agent")
+	}
+
+	expectedAgents := []string{"opencode", "claude", "codex", "cursor", "windsurf", "cline"}
+	for _, name := range expectedAgents {
+		found := false
+		for _, a := range agents {
+			if a.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected agent '%s' to be supported", name)
+		}
+	}
+}
+
+func TestFindAgent(t *testing.T) {
+	agent, ok := FindAgent("opencode")
+	if !ok {
+		t.Fatal("expected to find opencode agent")
+	}
+	if agent.ConfigFile != "AGENTS.md" {
+		t.Errorf("expected AGENTS.md config file, got %s", agent.ConfigFile)
+	}
+
+	agent, ok = FindAgent("claude")
+	if !ok {
+		t.Fatal("expected to find claude agent")
+	}
+	if agent.ConfigFile != "CLAUDE.md" {
+		t.Errorf("expected CLAUDE.md config file, got %s", agent.ConfigFile)
+	}
+
+	agent, ok = FindAgent("codex")
+	if !ok {
+		t.Fatal("expected to find codex agent")
+	}
+
+	_, ok = FindAgent("nonexistent")
+	if ok {
+		t.Error("expected FindAgent to return false for nonexistent agent")
+	}
+}
+
+func TestAgentList(t *testing.T) {
+	list := AgentList()
+	if list == "" {
+		t.Error("expected non-empty agent list")
+	}
+	for _, name := range []string{"opencode", "claude", "codex", "cursor", "windsurf", "cline"} {
+		if !strings.Contains(list, name) {
+			t.Errorf("expected agent list to contain '%s'", name)
+		}
+	}
+}
+
+func TestSetupAgent(t *testing.T) {
+	skills := testSkills()
+
+	for _, agentName := range []string{"opencode", "claude", "codex", "cursor", "windsurf", "cline"} {
+		t.Run(agentName, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			origDir, _ := os.Getwd()
+			os.Chdir(tmpDir)
+			defer os.Chdir(origDir)
+
+			err := SetupAgent(agentName, skills)
+			if err != nil {
+				t.Fatalf("SetupAgent(%s) failed: %v", agentName, err)
+			}
+
+			agent, _ := FindAgent(agentName)
+			configPath := filepath.Join(tmpDir, agent.ConfigFile)
+
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("failed to read %s config: %v", agentName, err)
+			}
+
+			content := string(data)
+
+			if !strings.Contains(content, "migraine") {
+				t.Errorf("expected %s config to mention migraine", agentName)
+			}
+			if !strings.Contains(content, "migraine-workflow") {
+				t.Errorf("expected %s config to mention migraine-workflow skill", agentName)
+			}
+			if !strings.Contains(content, "migraine run") {
+				t.Errorf("expected %s config to mention 'migraine run'", agentName)
+			}
+			if !strings.Contains(content, "migraine skill add") {
+				t.Errorf("expected %s config to mention 'migraine skill add'", agentName)
+			}
+		})
+	}
+}
+
+func TestSetupAgentInvalid(t *testing.T) {
+	err := SetupAgent("nonexistent", testSkills())
+	if err == nil {
+		t.Error("expected error for invalid agent name")
+	}
+}
+
+func TestOpenCodeConfigContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	skills := testSkills()
+	err := SetupAgent("opencode", skills)
+	if err != nil {
+		t.Fatalf("SetupAgent(opencode) failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("failed to read AGENTS.md: %v", err)
+	}
+
+	content := string(data)
+	for _, expected := range []string{"migraine run", "migraine skill add", "migraine workflow list", ".mg", "args:VAR", "env:VAR", "vault:VAR"} {
+		if !strings.Contains(content, expected) {
+			t.Errorf("expected opencode config to contain '%s'", expected)
+		}
+	}
+}
+
+func TestClaudeConfigContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	skills := testSkills()
+	err := SetupAgent("claude", skills)
+	if err != nil {
+		t.Fatalf("SetupAgent(claude) failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("failed to read CLAUDE.md: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "migraine skill add") {
+		t.Error("expected claude config to mention 'migraine skill add'")
+	}
+	if !strings.Contains(content, ".mg") {
+		t.Error("expected claude config to mention .mg format")
+	}
+}
+
+func TestCursorConfigContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	skills := testSkills()
+	err := SetupAgent("cursor", skills)
+	if err != nil {
+		t.Fatalf("SetupAgent(cursor) failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, ".cursorrules"))
+	if err != nil {
+		t.Fatalf("failed to read .cursorrules: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "migraine skill list") {
+		t.Error("expected cursor config to mention 'migraine skill list'")
+	}
+}

--- a/internal/skill/registry.go
+++ b/internal/skill/registry.go
@@ -1,0 +1,282 @@
+package skill
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tesh254/migraine/internal/ui"
+	"gopkg.in/yaml.v3"
+)
+
+type Skill struct {
+	Name        string            `yaml:"name"`
+	Description string            `yaml:"description"`
+	Category    string            `yaml:"category"`
+	Tags        []string          `yaml:"tags,omitempty"`
+	Variables   map[string]string `yaml:"variables,omitempty"`
+	Workflow    SkillWorkflow     `yaml:"workflow"`
+}
+
+type SkillWorkflow struct {
+	PreChecks []SkillStep          `yaml:"pre_checks,omitempty"`
+	Steps     []SkillStep          `yaml:"steps"`
+	Actions   map[string]SkillStep `yaml:"actions,omitempty"`
+}
+
+type SkillStep struct {
+	Command     string  `yaml:"command"`
+	Description *string `yaml:"description,omitempty"`
+	OnFail      string  `yaml:"on_fail,omitempty"`
+	OnSuccess   string  `yaml:"on_success,omitempty"`
+}
+
+var builtinSkills = []Skill{
+	{
+		Name:        "migraine-workflow",
+		Description:  "Scaffold a new migraine workflow from scratch",
+		Category:    "migraine",
+		Tags:        []string{"migraine", "workflow", "scaffold", "init", "setup"},
+		Workflow: SkillWorkflow{
+			Steps: []SkillStep{
+				{Command: "migraine workflow init", Description: strPtr("Create migraine.yml project config")},
+				{Command: "migraine workflow validate migraine.yml", Description: strPtr("Validate the generated workflow")},
+			},
+		},
+	},
+}
+
+func strPtr(s string) *string { return &s }
+
+var globalSkillDirFn = defaultGlobalSkillDir
+var projectSkillDirFn = defaultProjectSkillDir
+
+func defaultGlobalSkillDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".migraine", "skills"), nil
+}
+
+func defaultProjectSkillDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cwd, ".migraine", "skills"), nil
+}
+
+func List() []Skill {
+	return builtinSkills
+}
+
+func Find(name string) (*Skill, bool) {
+	for _, s := range builtinSkills {
+		if s.Name == name {
+			return &s, true
+		}
+	}
+	return nil, false
+}
+
+func Search(query string) []Skill {
+	q := strings.ToLower(query)
+	var results []Skill
+	for _, s := range builtinSkills {
+		if strings.Contains(strings.ToLower(s.Name), q) ||
+			strings.Contains(strings.ToLower(s.Description), q) ||
+			strings.Contains(strings.ToLower(s.Category), q) {
+			results = append(results, s)
+			continue
+		}
+		for _, t := range s.Tags {
+			if strings.Contains(strings.ToLower(t), q) {
+				results = append(results, s)
+				break
+			}
+		}
+	}
+	return results
+}
+
+func Install(name string, scope string) error {
+	s, ok := Find(name)
+	if !ok {
+		return fmt.Errorf("skill '%s' not found. Use 'migraine skill list' to see available skills", name)
+	}
+
+	var dir string
+	var err error
+	switch scope {
+	case "global":
+		dir, err = globalSkillDirFn()
+	case "project":
+		dir, err = projectSkillDirFn()
+	default:
+		return fmt.Errorf("invalid scope '%s': must be 'global' or 'project'", scope)
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create skills directory: %v", err)
+	}
+
+	filename := filepath.Join(dir, s.Name+".yaml")
+
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("failed to marshal skill: %v", err)
+	}
+
+	if err := os.WriteFile(filename, data, 0644); err != nil {
+		return fmt.Errorf("failed to write skill file: %v", err)
+	}
+
+	ui.LogSuccessBordered(fmt.Sprintf("Skill '%s' installed (%s)", s.Name, scope))
+	ui.SectionHeader("Details")
+	fmt.Printf("  Name:        %s\n", s.Name)
+	fmt.Printf("  Description: %s\n", s.Description)
+	fmt.Printf("  Category:    %s\n", s.Category)
+	fmt.Printf("  Location:    %s\n", filename)
+	if len(s.Variables) > 0 {
+		fmt.Printf("  Variables:   %s\n", strings.Join(mapKeys(s.Variables), ", "))
+	}
+	fmt.Printf("\n  Run with: migraine run %s\n", s.Name)
+	return nil
+}
+
+func Remove(name string) error {
+	dirs := []string{}
+
+	globalDir, err := globalSkillDirFn()
+	if err == nil {
+		dirs = append(dirs, globalDir)
+	}
+	projectDir, err := projectSkillDirFn()
+	if err == nil {
+		dirs = append(dirs, projectDir)
+	}
+
+	for _, dir := range dirs {
+		filename := filepath.Join(dir, name+".yaml")
+		if _, err := os.Stat(filename); err == nil {
+			if err := os.Remove(filename); err != nil {
+				return fmt.Errorf("failed to remove skill file: %v", err)
+			}
+			ui.LogSuccessBordered(fmt.Sprintf("Skill '%s' removed from %s", name, dir))
+			return nil
+		}
+	}
+
+	return fmt.Errorf("skill '%s' is not installed", name)
+}
+
+func ListInstalled() ([]string, error) {
+	var installed []string
+
+	globalDir, err := globalSkillDirFn()
+	if err == nil {
+		files, _ := filepath.Glob(filepath.Join(globalDir, "*.yaml"))
+		for _, f := range files {
+			name := strings.TrimSuffix(filepath.Base(f), ".yaml")
+			installed = append(installed, name+" (global)")
+		}
+	}
+
+	projectDir, err := projectSkillDirFn()
+	if err == nil {
+		files, _ := filepath.Glob(filepath.Join(projectDir, "*.yaml"))
+		for _, f := range files {
+			name := strings.TrimSuffix(filepath.Base(f), ".yaml")
+			installed = append(installed, name+" (project)")
+		}
+	}
+
+	return installed, nil
+}
+
+func RenderMG(s *Skill) string {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("metadata {\n"))
+	b.WriteString(fmt.Sprintf("    name = \"%s\"\n", s.Name))
+	b.WriteString(fmt.Sprintf("    desc = \"%s\"\n", s.Description))
+	b.WriteString("}\n\n")
+
+	if len(s.Variables) > 0 {
+		b.WriteString("variables {\n")
+		for k, v := range s.Variables {
+			b.WriteString(fmt.Sprintf("    %s = \"%s\"\n", k, v))
+		}
+		b.WriteString("}\n\n")
+	}
+
+	b.WriteString("workflow {\n")
+
+	if len(s.Workflow.PreChecks) > 0 {
+		b.WriteString("    pre_checks [\n")
+		for _, pc := range s.Workflow.PreChecks {
+			b.WriteString("        {\n")
+			b.WriteString(fmt.Sprintf("            cmd = `%s`\n", pc.Command))
+			if pc.Description != nil {
+				b.WriteString(fmt.Sprintf("            desc = \"%s\"\n", *pc.Description))
+			}
+			if pc.OnFail != "" {
+				b.WriteString(fmt.Sprintf("            on_fail = \"%s\"\n", pc.OnFail))
+			}
+			if pc.OnSuccess != "" {
+				b.WriteString(fmt.Sprintf("            on_success = \"%s\"\n", pc.OnSuccess))
+			}
+			b.WriteString("        },\n")
+		}
+		b.WriteString("    ]\n\n")
+	}
+
+	b.WriteString("    steps [\n")
+	for _, step := range s.Workflow.Steps {
+		b.WriteString("        {\n")
+		b.WriteString(fmt.Sprintf("            cmd = `%s`\n", step.Command))
+		if step.Description != nil {
+			b.WriteString(fmt.Sprintf("            desc = \"%s\"\n", *step.Description))
+		}
+		if step.OnFail != "" {
+			b.WriteString(fmt.Sprintf("            on_fail = \"%s\"\n", step.OnFail))
+		}
+		if step.OnSuccess != "" {
+			b.WriteString(fmt.Sprintf("            on_success = \"%s\"\n", step.OnSuccess))
+		}
+		b.WriteString("        },\n")
+	}
+	b.WriteString("    ]\n")
+
+	if len(s.Workflow.Actions) > 0 {
+		b.WriteString("\n    actions {\n")
+		for name, action := range s.Workflow.Actions {
+			b.WriteString(fmt.Sprintf("        %s {\n", name))
+			b.WriteString(fmt.Sprintf("            cmd = `%s`\n", action.Command))
+			if action.Description != nil {
+				b.WriteString(fmt.Sprintf("            desc = \"%s\"\n", *action.Description))
+			}
+			if action.OnFail != "" {
+				b.WriteString(fmt.Sprintf("            on_fail = \"%s\"\n", action.OnFail))
+			}
+			b.WriteString("        },\n")
+		}
+		b.WriteString("    }\n")
+	}
+
+	b.WriteString("}\n")
+	return b.String()
+}
+
+func mapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/skill/registry_test.go
+++ b/internal/skill/registry_test.go
@@ -1,0 +1,243 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestList(t *testing.T) {
+	skills := List()
+	if len(skills) == 0 {
+		t.Fatal("expected at least one built-in skill, got none")
+	}
+
+	found := false
+	for _, s := range skills {
+		if s.Name == "migraine-workflow" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected migraine-workflow skill to exist in built-in skills")
+	}
+}
+
+func TestFind(t *testing.T) {
+	s, ok := Find("migraine-workflow")
+	if !ok {
+		t.Fatal("expected to find migraine-workflow skill")
+	}
+	if s.Name != "migraine-workflow" {
+		t.Errorf("expected name=migraine-workflow, got %s", s.Name)
+	}
+	if s.Category != "migraine" {
+		t.Errorf("expected category=migraine, got %s", s.Category)
+	}
+}
+
+func TestFindNotFound(t *testing.T) {
+	_, ok := Find("nonexistent-skill")
+	if ok {
+		t.Error("expected Find to return false for nonexistent skill")
+	}
+}
+
+func TestSearch(t *testing.T) {
+	results := Search("migraine")
+	if len(results) == 0 {
+		t.Fatal("expected at least one result for 'migraine' search")
+	}
+
+	found := false
+	for _, s := range results {
+		if s.Name == "migraine-workflow" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected migraine-workflow in search results for 'migraine'")
+	}
+}
+
+func TestSearchByTag(t *testing.T) {
+	results := Search("scaffold")
+	if len(results) == 0 {
+		t.Fatal("expected at least one result for 'scaffold' search (tag)")
+	}
+}
+
+func TestSearchNoResults(t *testing.T) {
+	results := Search("zzznonexistent")
+	if len(results) != 0 {
+		t.Error("expected no results for nonsensical search")
+	}
+}
+
+func TestInstallAndRemove(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origGlobal := globalSkillDirFn
+	origProject := projectSkillDirFn
+	defer func() {
+		globalSkillDirFn = origGlobal
+		projectSkillDirFn = origProject
+	}()
+
+	globalSkillDirFn = func() (string, error) { return filepath.Join(tmpDir, "global", ".migraine", "skills"), nil }
+	projectSkillDirFn = func() (string, error) { return filepath.Join(tmpDir, "project", ".migraine", "skills"), nil }
+
+	err := Install("migraine-workflow", "global")
+	if err != nil {
+		t.Fatalf("Install global failed: %v", err)
+	}
+
+	globalPath := filepath.Join(tmpDir, "global", ".migraine", "skills", "migraine-workflow.yaml")
+	if _, err := os.Stat(globalPath); os.IsNotExist(err) {
+		t.Error("expected skill file to exist at global path")
+	}
+
+	err = Install("migraine-workflow", "project")
+	if err != nil {
+		t.Fatalf("Install project failed: %v", err)
+	}
+
+	projectPath := filepath.Join(tmpDir, "project", ".migraine", "skills", "migraine-workflow.yaml")
+	if _, err := os.Stat(projectPath); os.IsNotExist(err) {
+		t.Error("expected skill file to exist at project path")
+	}
+
+	installed, err := ListInstalled()
+	if err != nil {
+		t.Fatalf("ListInstalled failed: %v", err)
+	}
+	if len(installed) == 0 {
+		t.Error("expected at least one installed skill")
+	}
+
+	foundGlobal := false
+	foundProject := false
+	for _, i := range installed {
+		if strings.Contains(i, "migraine-workflow") && strings.Contains(i, "global") {
+			foundGlobal = true
+		}
+		if strings.Contains(i, "migraine-workflow") && strings.Contains(i, "project") {
+			foundProject = true
+		}
+	}
+	if !foundGlobal {
+		t.Error("expected migraine-workflow (global) in installed list")
+	}
+	if !foundProject {
+		t.Error("expected migraine-workflow (project) in installed list")
+	}
+
+	err = Remove("migraine-workflow")
+	if err != nil {
+		t.Fatalf("first Remove failed: %v", err)
+	}
+
+	// Second call removes the project copy
+	err = Remove("migraine-workflow")
+	if err != nil {
+		t.Fatalf("second Remove failed: %v", err)
+	}
+
+	// Third call should fail since neither copy exists
+	err = Remove("migraine-workflow")
+	if err == nil {
+		t.Error("expected error when removing skill with no remaining copies")
+	}
+}
+
+func TestInstallInvalidScope(t *testing.T) {
+	err := Install("migraine-workflow", "invalid")
+	if err == nil {
+		t.Error("expected error for invalid scope")
+	}
+}
+
+func TestInstallNonexistentSkill(t *testing.T) {
+	err := Install("nonexistent-skill", "project")
+	if err == nil {
+		t.Error("expected error for nonexistent skill")
+	}
+}
+
+func TestRemoveNonexistentSkill(t *testing.T) {
+	err := Remove("totally-fake-skill")
+	if err == nil {
+		t.Error("expected error when removing nonexistent skill")
+	}
+}
+
+func TestRenderMG(t *testing.T) {
+	s, ok := Find("migraine-workflow")
+	if !ok {
+		t.Fatal("migraine-workflow skill not found")
+	}
+
+	output := RenderMG(s)
+
+	if !strings.Contains(output, "metadata {") {
+		t.Error("expected metadata block in .mg output")
+	}
+	if !strings.Contains(output, `name = "migraine-workflow"`) {
+		t.Error("expected name in .mg output")
+	}
+	if !strings.Contains(output, "workflow {") {
+		t.Error("expected workflow block in .mg output")
+	}
+	if !strings.Contains(output, "steps [") {
+		t.Error("expected steps block in .mg output")
+	}
+	if !strings.Contains(output, "cmd =") {
+		t.Error("expected cmd fields in .mg output")
+	}
+}
+
+func TestRenderMGWithAllFields(t *testing.T) {
+	desc := "test step"
+	s := &Skill{
+		Name:        "test-skill",
+		Description:  "A test",
+		Category:    "test",
+		Tags:        []string{"test"},
+		Variables:   map[string]string{"VAR1": "args:VAR1"},
+		Workflow: SkillWorkflow{
+			PreChecks: []SkillStep{
+				{Command: "echo precheck", Description: &desc, OnFail: "action:fail"},
+			},
+			Steps: []SkillStep{
+				{Command: "echo step1", Description: &desc, OnFail: "action:fail", OnSuccess: "action:ok"},
+			},
+			Actions: map[string]SkillStep{
+				"fail": {Command: "echo failed", Description: &desc},
+			},
+		},
+	}
+
+	output := RenderMG(s)
+
+	if !strings.Contains(output, "pre_checks [") {
+		t.Error("expected pre_checks in output")
+	}
+	if !strings.Contains(output, `on_fail = "action:fail"`) {
+		t.Error("expected on_fail in output")
+	}
+	if !strings.Contains(output, `on_success = "action:ok"`) {
+		t.Error("expected on_success in output")
+	}
+	if !strings.Contains(output, "actions {") {
+		t.Error("expected actions block in output")
+	}
+	if !strings.Contains(output, "variables {") {
+		t.Error("expected variables block in output")
+	}
+	if !strings.Contains(output, `VAR1 = "args:VAR1"`) {
+		t.Error("expected VAR1 in output")
+	}
+}

--- a/internal/workflow/discovery.go
+++ b/internal/workflow/discovery.go
@@ -7,21 +7,31 @@ import (
 	"strings"
 )
 
-// DiscoverWorkflowsFromCWD discovers all YAML workflows in the current working directory
+func skillDirs() []string {
+	var dirs []string
+	cwd, err := os.Getwd()
+	if err == nil {
+		dirs = append(dirs, filepath.Join(cwd, ".migraine", "skills"))
+	}
+	home, err := os.UserHomeDir()
+	if err == nil {
+		dirs = append(dirs, filepath.Join(home, ".migraine", "skills"))
+	}
+	return dirs
+}
+
+// DiscoverWorkflowsFromCWD discovers all workflows (YAML, .mg, and installed skills) in the current working directory
 func DiscoverWorkflowsFromCWD() ([]YAMLWorkflow, error) {
-	// Look for workflows in both ./workflows and . directories
 	workflowDirs := []string{"./workflows", "."}
 
 	var allWorkflows []YAMLWorkflow
 
 	for _, dir := range workflowDirs {
-		// Check if the directory exists
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
 			continue
 		}
 
-		// Find all YAML files in the directory
-		yamlFiles, err := filepath.Glob(filepath.Join(dir, "*.y*ml")) // matches .yaml and .yml
+		yamlFiles, err := filepath.Glob(filepath.Join(dir, "*.y*ml"))
 		if err != nil {
 			return nil, err
 		}
@@ -29,15 +39,26 @@ func DiscoverWorkflowsFromCWD() ([]YAMLWorkflow, error) {
 		for _, file := range yamlFiles {
 			workflow, err := LoadYAMLWorkflow(file)
 			if err != nil {
-				// Log the error but continue processing other files
 				fmt.Printf("Warning: failed to load workflow from %s: %v\n", file, err)
 				continue
 			}
-
 			allWorkflows = append(allWorkflows, *workflow)
 		}
 
-		// Check for Migraine file
+		mgFiles, err := filepath.Glob(filepath.Join(dir, "*.mg"))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, file := range mgFiles {
+			workflow, err := LoadMigraineWorkflow(file)
+			if err != nil {
+				fmt.Printf("Warning: failed to load workflow from %s: %v\n", file, err)
+				continue
+			}
+			allWorkflows = append(allWorkflows, *workflow)
+		}
+
 		migraineFile := filepath.Join(dir, "Migraine")
 		if _, err := os.Stat(migraineFile); err == nil {
 			workflow, err := loadProjectWorkflowFromMigraine(migraineFile)
@@ -46,6 +67,34 @@ func DiscoverWorkflowsFromCWD() ([]YAMLWorkflow, error) {
 			} else {
 				allWorkflows = append(allWorkflows, *workflow)
 			}
+		}
+	}
+
+	for _, dir := range skillDirs() {
+		yamlFiles, err := filepath.Glob(filepath.Join(dir, "*.y*ml"))
+		if err != nil {
+			continue
+		}
+		for _, file := range yamlFiles {
+			workflow, err := LoadYAMLWorkflow(file)
+			if err != nil {
+				fmt.Printf("Warning: failed to load skill from %s: %v\n", file, err)
+				continue
+			}
+			allWorkflows = append(allWorkflows, *workflow)
+		}
+
+		mgFiles, err := filepath.Glob(filepath.Join(dir, "*.mg"))
+		if err != nil {
+			continue
+		}
+		for _, file := range mgFiles {
+			workflow, err := LoadMigraineWorkflow(file)
+			if err != nil {
+				fmt.Printf("Warning: failed to load skill from %s: %v\n", file, err)
+				continue
+			}
+			allWorkflows = append(allWorkflows, *workflow)
 		}
 	}
 
@@ -84,7 +133,7 @@ func GetWorkflowFilePath(name string) (string, error) {
 			continue
 		}
 
-		patterns := []string{"*.yaml", "*.yml"}
+		patterns := []string{"*.yaml", "*.yml", "*.mg"}
 
 		for _, pattern := range patterns {
 			files, err := filepath.Glob(filepath.Join(dir, pattern))
@@ -95,6 +144,28 @@ func GetWorkflowFilePath(name string) (string, error) {
 			for _, file := range files {
 				filename := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
 
+				if filename == name {
+					return file, nil
+				}
+			}
+		}
+	}
+
+	for _, dir := range skillDirs() {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			continue
+		}
+
+		patterns := []string{"*.yaml", "*.yml", "*.mg"}
+
+		for _, pattern := range patterns {
+			files, err := filepath.Glob(filepath.Join(dir, pattern))
+			if err != nil {
+				continue
+			}
+
+			for _, file := range files {
+				filename := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
 				if filename == name {
 					return file, nil
 				}

--- a/internal/workflow/discovery_test.go
+++ b/internal/workflow/discovery_test.go
@@ -1,0 +1,266 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverWorkflowsFromCWD_YAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	origWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origWd)
+
+	yamlContent := []byte("name: test-yaml\nsteps:\n  - command: echo hello\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, "test-yaml.yaml"), yamlContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflows, err := DiscoverWorkflowsFromCWD()
+	if err != nil {
+		t.Fatalf("DiscoverWorkflowsFromCWD() error: %v", err)
+	}
+
+	found := false
+	for _, wf := range workflows {
+		if wf.Name == "test-yaml" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find test-yaml workflow from YAML file")
+	}
+}
+
+func TestDiscoverWorkflowsFromCWD_MG(t *testing.T) {
+	tmpDir := t.TempDir()
+	origWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origWd)
+
+	mgContent := []byte(`metadata {
+    name = "test-mg"
+    desc = "A test .mg workflow"
+}
+
+workflow {
+    steps [
+        {
+            cmd = ` + "`echo hello`" + `
+            desc = "Say hello"
+        }
+    ]
+}
+`)
+	if err := os.WriteFile(filepath.Join(tmpDir, "test-mg.mg"), mgContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflows, err := DiscoverWorkflowsFromCWD()
+	if err != nil {
+		t.Fatalf("DiscoverWorkflowsFromCWD() error: %v", err)
+	}
+
+	found := false
+	for _, wf := range workflows {
+		if wf.Name == "test-mg" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find test-mg workflow from .mg file")
+	}
+}
+
+func TestDiscoverWorkflowsFromCWD_SkillDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origWd)
+
+	skillDir := filepath.Join(tmpDir, ".migraine", "skills")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := []byte("name: skill-workflow\nsteps:\n  - command: echo skill\n")
+	if err := os.WriteFile(filepath.Join(skillDir, "skill-workflow.yaml"), yamlContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflows, err := DiscoverWorkflowsFromCWD()
+	if err != nil {
+		t.Fatalf("DiscoverWorkflowsFromCWD() error: %v", err)
+	}
+
+	found := false
+	for _, wf := range workflows {
+		if wf.Name == "skill-workflow" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find skill-workflow from .migraine/skills directory")
+	}
+}
+
+func TestDiscoverWorkflowsFromCWD_GlobalSkillDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origWd)
+
+	homeSkillDir := filepath.Join(tmpDir, "home", ".migraine", "skills")
+	if err := os.MkdirAll(homeSkillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	os.Setenv("HOME", filepath.Join(tmpDir, "home"))
+	defer os.Unsetenv("HOME")
+
+	yamlContent := []byte("name: global-skill\nsteps:\n  - command: echo global\n")
+	if err := os.WriteFile(filepath.Join(homeSkillDir, "global-skill.yaml"), yamlContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflows, err := DiscoverWorkflowsFromCWD()
+	if err != nil {
+		t.Fatalf("DiscoverWorkflowsFromCWD() error: %v", err)
+	}
+
+	found := false
+	for _, wf := range workflows {
+		if wf.Name == "global-skill" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find global-skill from global skills directory")
+	}
+}
+
+func TestDiscoverWorkflowsFromCWD_WorkflowsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origWd)
+
+	wfDir := filepath.Join(tmpDir, "workflows")
+	if err := os.MkdirAll(wfDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := []byte("name: sub-dir-wf\nsteps:\n  - command: echo sub\n")
+	if err := os.WriteFile(filepath.Join(wfDir, "sub-dir-wf.yaml"), yamlContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflows, err := DiscoverWorkflowsFromCWD()
+	if err != nil {
+		t.Fatalf("DiscoverWorkflowsFromCWD() error: %v", err)
+	}
+
+	found := false
+	for _, wf := range workflows {
+		if wf.Name == "sub-dir-wf" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find sub-dir-wf from workflows/ directory")
+	}
+}
+
+func TestFindWorkflowByName(t *testing.T) {
+	tmpDir := t.TempDir()
+	origWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origWd)
+
+	yamlContent := []byte("name: my-workflow\nsteps:\n  - command: echo test\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, "my-workflow.yaml"), yamlContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	wf, err := FindWorkflowByName("my-workflow")
+	if err != nil {
+		t.Fatalf("FindWorkflowByName() error: %v", err)
+	}
+	if wf.Name != "my-workflow" {
+		t.Errorf("expected workflow name my-workflow, got %s", wf.Name)
+	}
+
+	_, err = FindWorkflowByName("nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent workflow name")
+	}
+}
+
+func TestFindWorkflowByName_MG(t *testing.T) {
+	tmpDir := t.TempDir()
+	origWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origWd)
+
+	mgContent := []byte(`metadata {
+    name = "my-mg-wf"
+}
+
+workflow {
+    steps [
+        {
+            cmd = ` + "`echo mg`" + `
+        }
+    ]
+}
+`)
+	if err := os.WriteFile(filepath.Join(tmpDir, "my-mg-wf.mg"), mgContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	wf, err := FindWorkflowByName("my-mg-wf")
+	if err != nil {
+		t.Fatalf("FindWorkflowByName() error: %v", err)
+	}
+	if wf.Name != "my-mg-wf" {
+		t.Errorf("expected workflow name my-mg-wf, got %s", wf.Name)
+	}
+}
+
+func TestGetWorkflowFilePath_MG(t *testing.T) {
+	tmpDir := t.TempDir()
+	origWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origWd)
+
+	mgContent := []byte(`metadata { name = "findme" } workflow { steps [{ cmd = ` + "`echo hi`" + ` }] }`)
+	if err := os.WriteFile(filepath.Join(tmpDir, "findme.mg"), mgContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := GetWorkflowFilePath("findme")
+	if err != nil {
+		t.Fatalf("GetWorkflowFilePath() error: %v", err)
+	}
+	if filepath.Base(path) != "findme.mg" {
+		t.Errorf("expected findme.mg, got %s", filepath.Base(path))
+	}
+}
+
+func TestGetWorkflowFilePath_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	origWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origWd)
+
+	_, err := GetWorkflowFilePath("nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent workflow file")
+	}
+}

--- a/internal/workflow/migraine_parser.go
+++ b/internal/workflow/migraine_parser.go
@@ -13,6 +13,20 @@ type MigraineParser struct {
 	peekToken Token
 }
 
+func LoadMigraineWorkflow(path string) (*YAMLWorkflow, error) {
+	p, err := NewMigraineParser(path)
+	if err != nil {
+		return nil, err
+	}
+	wf, err := p.Parse()
+	if err != nil {
+		return nil, err
+	}
+	yamlWf := ConvertInternalToYAML(wf, "")
+	yamlWf.Path = path
+	return yamlWf, nil
+}
+
 func NewMigraineParser(path string) (*MigraineParser, error) {
 	file, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Skill system**: registry (list/find/search/install/remove/renderMG), CLI subcommands (`migraine skill list/add/remove/show/search/init`)
- **Agent integration**: config generators for opencode, claude, codex, cursor, windsurf, cline via `migraine skill init --agent <name>`
- **`.mg` file discovery**: `LoadMigraineWorkflow()` + updated `DiscoverWorkflowsFromCWD()` and `GetWorkflowFilePath()` to find `.mg` files and skill directories
- **Interactive stdin fix**: replaced PTY-based `ExecuteCommand` with direct stdio (`cmd.Stdin/Stdout/Stderr = os.Stdin/Stdout/Stderr`). Root cause of double-Enter was PTY goroutine `io.Copy(ptmx, os.Stdin)` stealing bytes between sequential workflow steps
- **Removed `creack/pty` and `golang.org/x/term`** dependencies (no longer needed)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — 31 tests pass (skill: 11+8, shell: 4, discovery: 8)
- [x] Interactive workflow: single Enter responds to `read -p` prompts
- [x] Password prompts (`read -sp`) — echo suppression works natively via real terminal fd
- [ ] Manual: `cp examples/test-interactive.mg . && migraine run test-interactive`